### PR TITLE
Use `only-shallow` instead of `JSON.stringify()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 'use strict';
+var deepEqual = require('only-shallow');
+
 module.exports = function (input, values) {
 	if (!Array.isArray(values)) {
 		throw new TypeError('Expected an array');
 	}
 
 	for (var i = 0; i < values.length; i++) {
-		if (input === values[i] || JSON.stringify(input) === JSON.stringify(values[i])) {
+		if (input === values[i] || deepEqual(input, values[i])) {
 			return true;
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "values",
     "test"
   ],
+  "dependencies": {
+    "only-shallow": "^1.2.0"
+  },
   "devDependencies": {
     "ava": "*",
     "xo": "*"


### PR DESCRIPTION
Because `JSON.stringify()` requires to objects to be structured exactly the same which is kinda flaky.

``` js
JSON.stringify({a: 'foo', b: 'foo'}) === JSON.stringify({b: 'foo', a: 'foo'});
//=> false
```
